### PR TITLE
Fix comments and strings

### DIFF
--- a/Syntaxes/JavaLanguage.xml
+++ b/Syntaxes/JavaLanguage.xml
@@ -92,10 +92,10 @@
         </collection>
         <collection name="strings">
             <scope name="java.string">
-                <expression>&quot;.*&quot;</expression>
+                <expression>&quot;([^\\&quot;]|\\[^&quot;]|[^\\]?(\\\\)*\\&quot;)*&quot;</expression>
             </scope>
             <scope name="java.string">
-                <expression>&apos;.*&apos;</expression>
+                <expression>&apos;\\?.&apos;</expression>
             </scope>
         </collection>
         <collection name="numbers">

--- a/Syntaxes/JavaLanguage.xml
+++ b/Syntaxes/JavaLanguage.xml
@@ -20,17 +20,17 @@
     </indentation>
     
     <comments>
-        <!-- <multiline>
+        <multiline>
             <starts-with>
-                <expression>/*</expression>
+                <expression>/\*</expression>
             </starts-with>
             <ends-with>
-                <expression>*/</expression>
+                <expression>\*/</expression>
             </ends-with>
         </multiline>
         <single>
             <expression>//</expression>
-        </single> -->
+        </single>
     </comments>
     
     <brackets>

--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
     "name": "Java Language Definition",
     "organization": "Matt Farmer",
     "description": "Minimal, straightforward Java language highlighting for Nova.",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "categories": ["languages"],
     "repository": "https://github.com/farmdawgnation/nova-java-language",
     "homepage": "https://github.com/farmdawgnation/nova-java-language",


### PR DESCRIPTION
1. Cmd+/ now works to toggle commenting a block of code.
2. Previously `"foo" + bar("baz")` would parse everything from the very first quote to the very last quote as one string.